### PR TITLE
Decreasing frame rate of cv inference node

### DIFF
--- a/cv/lane_detection/src/lane_detection_inference.py
+++ b/cv/lane_detection/src/lane_detection_inference.py
@@ -70,11 +70,18 @@ class CVModelInferencer:
         # self.hack = cv2.imread(r'/home/ammarvora/utra/espresso-ws/src/Espresso/cv/lane_detection/src/lane.png')
 
         # print(self.hack.shape)
-
+        
+        # Frame skipping logic to reduce computation load (30 fps vs 5 fps, every 5th frame is processes)
+        self.frame_count = 0
+        self.frame_skip = 5
+        
+        # sets node rate to 5 Hz
+        self.rate = rospy.Rate(5)
 
         
     def run(self):
-        rospy.Subscriber("/image", Image, self.process_image)
+        #ensures only latest frame is processed, mitigates lag
+        rospy.Subscriber("/image", Image, self.process_image, queue_size = 1)
         rospy.spin()
    
     def lane_transform(self, img):
@@ -100,7 +107,12 @@ class CVModelInferencer:
 
 
     def process_image(self, data):
-        if data == []:
+        '''if data == []:
+            return'''
+            
+        # frame skipping logic
+        self.frame_count += 1
+        if self.frame_count % self.frame_skip != 0:
             return
             
         raw = self.bridge.imgmsg_to_cv2(data, desired_encoding='passthrough')
@@ -205,6 +217,9 @@ class CVModelInferencer:
             msg = FloatArray(header=msg_header, lists=[lane_msg])
             msg.header.stamp = data.header.stamp
             self.pub.publish(msg)
+            
+            # ensures controlled publishing rate
+            self.rate.sleep()
 
                 
 


### PR DESCRIPTION
NOTE: DO NOT MERGE PULL REQUEST, I WILL COMPARE WITH MAIN LAPTOP FIRST AND THEN MERGE

This functionality lets us change the framerate of the CV inference node. We need the frame skipping logic for computational load reasons.

With 5 fps, CPU load is reduced by 67% and inference speed is cut in half. Model is more stable overall.

However, tests and benchmarks are needed to find optimal values. TODO: also mess around with changing camera frame rate.